### PR TITLE
feat: H1 Docker Compose for Redpanda - One-liner local broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This will start:
 - **Java 21+** (for backend)
 - **Node.js 18+** (for frontend)
 - **npm** (for frontend dependencies)
+- **Docker & Docker Compose** (for Kafka/Redpanda broker)
 
 ## Manual Setup
 
@@ -65,6 +66,62 @@ cd backend && ./gradlew ktlintCheck
 
 # Frontend
 cd ui && npm run lint
+```
+
+## Kafka Development
+
+For development with Kafka/Redpanda message broker:
+
+### Start Redpanda Broker
+
+```bash
+# Start Redpanda single-node cluster with console
+docker compose up -d
+
+# Check broker status
+docker compose ps
+
+# View logs
+docker compose logs -f redpanda
+```
+
+### Redpanda Console
+
+Once running, access the Redpanda Console at:
+- **Console UI**: `http://localhost:8080`
+
+The console provides:
+- Topic management and inspection
+- Message browsing and publishing
+- Consumer group monitoring
+- Schema registry integration
+- Cluster health and metrics
+
+### Stop Broker
+
+```bash
+# Stop all services
+docker compose down
+
+# Stop and remove volumes (clean slate)
+docker compose down -v
+```
+
+### Useful Commands
+
+```bash
+# Create topics using rpk CLI in container
+docker exec -it redpanda rpk topic create events --partitions 3
+docker exec -it redpanda rpk topic create alerts --partitions 3
+
+# List topics
+docker exec -it redpanda rpk topic list
+
+# Produce test messages
+docker exec -it redpanda rpk topic produce events
+
+# Consume messages
+docker exec -it redpanda rpk topic consume events --print-headers
 ```
 
 ## Architecture

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,69 @@
+# Docker Compose configuration for Redpanda development environment
+# Provides single-node Kafka-compatible broker with web console
+
+services:
+  redpanda:
+    image: redpandadata/redpanda:v24.2.1
+    container_name: redpanda
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr internal://redpanda:9092,external://localhost:19092
+      - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
+      - --advertise-pandaproxy-addr internal://redpanda:8082,external://localhost:18082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr redpanda:33145
+      - --advertise-rpc-addr redpanda:33145
+      - --mode dev-container
+      - --smp 1
+      - --default-log-level=info
+    ports:
+      - "18081:18081"  # Schema Registry
+      - "18082:18082"  # HTTP Proxy
+      - "19092:19092"  # Kafka API
+      - "19644:9644"   # Admin API
+    volumes:
+      - redpanda_data:/var/lib/redpanda/data
+    healthcheck:
+      test: ["CMD-SHELL", "rpk cluster health | grep -E 'Healthy:.+true' || exit 1"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+    networks:
+      - redpanda_network
+
+  console:
+    image: redpandadata/console:v2.4.5
+    container_name: redpanda-console
+    entrypoint: /bin/sh
+    command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
+    environment:
+      CONFIG_FILEPATH: /tmp/config.yml
+      CONSOLE_CONFIG_FILE: |
+        kafka:
+          brokers: ["redpanda:9092"]
+          schemaRegistry:
+            enabled: true
+            urls: ["http://redpanda:8081"]
+        redpanda:
+          adminApi:
+            enabled: true
+            urls: ["http://redpanda:9644"]
+        connect:
+          enabled: false
+    ports:
+      - "8080:8080"
+    networks:
+      - redpanda_network
+    depends_on:
+      redpanda:
+        condition: service_healthy
+
+volumes:
+  redpanda_data:
+
+networks:
+  redpanda_network:
+    driver: bridge


### PR DESCRIPTION
## Summary
- ✅ Implements H1 (Docker Compose for Redpanda) from TICKETS.md
- ✅ Provides single-node Kafka-compatible broker with web console
- ✅ One-liner setup for local development
- ✅ Comprehensive documentation with usage commands

## Technical Implementation
- **Redpanda v24.2.1**: Latest stable Kafka-compatible broker
- **Console v2.4.5**: Web UI for topic management and monitoring
- **Proper Networking**: Internal/external listeners for container and host access
- **Health Checks**: Reliable startup sequence with dependency management
- **Port Mapping**: Standard ports for Kafka (19092), Console (8080), Schema/HTTP APIs

## Infrastructure
- **Kafka API**: `localhost:19092` for producer/consumer connections
- **Console UI**: `http://localhost:8080` for web interface
- **Schema Registry**: `localhost:18081` for schema management
- **HTTP Proxy**: `localhost:18082` for REST API access
- **Admin API**: `localhost:19644` for cluster administration

## Documentation
- Added comprehensive Kafka Development section to README
- Includes startup, management, and debugging commands
- Covers topic operations and message handling
- Added rpk CLI usage examples

## Test Plan
- [x] Create docker-compose.yml with proper service configuration
- [x] Configure networking and port mappings
- [x] Add healthcheck and startup dependencies
- [x] Test cluster startup with `docker compose up -d`
- [x] Verify console accessibility at localhost:8080
- [x] Validate cluster health via `rpk cluster health`
- [x] Update README with comprehensive usage guide

## DoD Compliance
✅ **docker compose up -d starts broker** - Single command deployment  
✅ **console reachable** - Web UI accessible at localhost:8080  
✅ **README section with commands** - Comprehensive developer guide  

🤖 Generated with [Claude Code](https://claude.ai/code)