### PR TITLE
[K1] CDP models & ingest API

### DIFF
--- a/backend/src/main/kotlin/com/pulseboard/cdp/api/CdpIngestController.kt
+++ b/backend/src/main/kotlin/com/pulseboard/cdp/api/CdpIngestController.kt
@@ -1,0 +1,61 @@
+package com.pulseboard.cdp.api
+
+import com.pulseboard.cdp.model.CdpEvent
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Shared flow for CDP events.
+ */
+@Component
+class CdpEventBus {
+    private val _events = MutableSharedFlow<CdpEvent>(
+        replay = 0,
+        extraBufferCapacity = 1000
+    )
+    val events: SharedFlow<CdpEvent> = _events.asSharedFlow()
+
+    suspend fun publish(event: CdpEvent) {
+        _events.emit(event)
+    }
+}
+
+/**
+ * REST controller for CDP event ingestion.
+ */
+@RestController
+@RequestMapping("/cdp")
+class CdpIngestController(
+    private val eventBus: CdpEventBus
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @PostMapping("/ingest")
+    suspend fun ingest(@RequestBody event: CdpEvent): ResponseEntity<Map<String, String>> {
+        return try {
+            // Validate the event
+            event.validate()
+            eventBus.publish(event)
+            logger.debug("Ingested CDP event: eventId={}, type={}", event.eventId, event.type)
+            ResponseEntity.status(HttpStatus.ACCEPTED)
+                .body(mapOf("status" to "accepted", "eventId" to event.eventId))
+        } catch (e: IllegalArgumentException) {
+            logger.warn("Validation failed for CDP event: {}", e.message)
+            ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(mapOf("status" to "error", "message" to (e.message ?: "Validation failed")))
+        } catch (e: Exception) {
+            logger.error("Error ingesting CDP event", e)
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(mapOf("status" to "error", "message" to "Internal server error"))
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/pulseboard/cdp/model/CdpEvent.kt
+++ b/backend/src/main/kotlin/com/pulseboard/cdp/model/CdpEvent.kt
@@ -1,0 +1,38 @@
+package com.pulseboard.cdp.model
+
+import java.time.Instant
+
+/**
+ * CDP Event model representing IDENTIFY, TRACK, or ALIAS events.
+ */
+data class CdpEvent(
+    val eventId: String,
+    val ts: Instant,
+    val type: CdpEventType,
+    val anonymousId: String? = null,
+    val userId: String? = null,
+    val email: String? = null,
+    val name: String? = null,
+    val properties: Map<String, Any?> = emptyMap(),
+    val traits: Map<String, Any?> = emptyMap()
+) {
+    /**
+     * Validates the event according to CDP requirements.
+     * Should be called explicitly after deserialization.
+     */
+    fun validate() {
+        require(eventId.isNotBlank()) { "eventId is required" }
+        require(anonymousId != null || userId != null || email != null) {
+            "At least one of anonymousId, userId, or email must be present"
+        }
+        if (type == CdpEventType.TRACK) {
+            require(!name.isNullOrBlank()) { "TRACK events require a name" }
+        }
+    }
+}
+
+enum class CdpEventType {
+    IDENTIFY,
+    TRACK,
+    ALIAS
+}

--- a/backend/src/main/kotlin/com/pulseboard/cdp/model/CdpProfile.kt
+++ b/backend/src/main/kotlin/com/pulseboard/cdp/model/CdpProfile.kt
@@ -1,0 +1,24 @@
+package com.pulseboard.cdp.model
+
+import java.time.Instant
+
+/**
+ * CDP Profile model representing a unified customer profile.
+ */
+data class CdpProfile(
+    val profileId: String,
+    val identifiers: ProfileIdentifiers,
+    val traits: Map<String, Any?> = emptyMap(),
+    val counters: Map<String, Long> = emptyMap(),
+    val segments: Set<String> = emptySet(),
+    val lastSeen: Instant
+)
+
+/**
+ * Profile identifiers grouped by type.
+ */
+data class ProfileIdentifiers(
+    val userIds: Set<String> = emptySet(),
+    val emails: Set<String> = emptySet(),
+    val anonymousIds: Set<String> = emptySet()
+)

--- a/backend/src/test/kotlin/com/pulseboard/cdp/api/CdpIngestControllerTest.kt
+++ b/backend/src/test/kotlin/com/pulseboard/cdp/api/CdpIngestControllerTest.kt
@@ -1,0 +1,248 @@
+package com.pulseboard.cdp.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.pulseboard.cdp.model.CdpEvent
+import com.pulseboard.cdp.model.CdpEventType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.time.Instant
+
+class CdpIngestControllerTest {
+    private lateinit var mockEventBus: CdpEventBus
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var controller: CdpIngestController
+    private lateinit var webTestClient: WebTestClient
+
+    @BeforeEach
+    fun setup() {
+        mockEventBus = mockk()
+        objectMapper = ObjectMapper().findAndRegisterModules()
+        controller = CdpIngestController(mockEventBus)
+        webTestClient = WebTestClient.bindToController(controller).build()
+
+        // Default behavior: allow event publishing
+        coEvery { mockEventBus.publish(any()) } returns Unit
+    }
+
+    @Test
+    fun `should accept valid TRACK event and return 202`() {
+        val eventJson =
+            """
+            {
+                "eventId": "evt-123",
+                "ts": "2025-10-04T10:30:00Z",
+                "type": "TRACK",
+                "userId": "user-123",
+                "name": "Feature Used",
+                "properties": {"feature": "dashboard"}
+            }
+            """.trimIndent()
+
+        webTestClient
+            .post()
+            .uri("/cdp/ingest")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(eventJson)
+            .exchange()
+            .expectStatus()
+            .isAccepted
+            .expectBody()
+            .jsonPath("$.status")
+            .isEqualTo("accepted")
+            .jsonPath("$.eventId")
+            .isEqualTo("evt-123")
+
+        coVerify { mockEventBus.publish(any()) }
+    }
+
+    @Test
+    fun `should accept valid IDENTIFY event with minimal fields`() {
+        val eventJson =
+            """
+            {
+                "eventId": "evt-456",
+                "ts": "2025-10-04T11:00:00Z",
+                "type": "IDENTIFY",
+                "email": "user@example.com"
+            }
+            """.trimIndent()
+
+        webTestClient
+            .post()
+            .uri("/cdp/ingest")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(eventJson)
+            .exchange()
+            .expectStatus()
+            .isAccepted
+            .expectBody()
+            .jsonPath("$.status")
+            .isEqualTo("accepted")
+
+        coVerify { mockEventBus.publish(any()) }
+    }
+
+    @Test
+    fun `should accept valid ALIAS event`() {
+        val eventJson =
+            """
+            {
+                "eventId": "evt-789",
+                "ts": "2025-10-04T12:00:00Z",
+                "type": "ALIAS",
+                "anonymousId": "anon-123",
+                "userId": "user-456"
+            }
+            """.trimIndent()
+
+        webTestClient
+            .post()
+            .uri("/cdp/ingest")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(eventJson)
+            .exchange()
+            .expectStatus()
+            .isAccepted
+            .expectBody()
+            .jsonPath("$.status")
+            .isEqualTo("accepted")
+
+        coVerify { mockEventBus.publish(any()) }
+    }
+
+    @Test
+    fun `should reject TRACK event without name`() {
+        val eventJson =
+            """
+            {
+                "eventId": "evt-invalid",
+                "ts": "2025-10-04T10:30:00Z",
+                "type": "TRACK",
+                "userId": "user-123"
+            }
+            """.trimIndent()
+
+        webTestClient
+            .post()
+            .uri("/cdp/ingest")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(eventJson)
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .expectBody()
+            .jsonPath("$.status")
+            .isEqualTo("error")
+            .jsonPath("$.message")
+            .value<String> { it.contains("TRACK events require a name") }
+
+        coVerify(exactly = 0) { mockEventBus.publish(any()) }
+    }
+
+    @Test
+    fun `should reject event without any identifier`() {
+        val eventJson =
+            """
+            {
+                "eventId": "evt-invalid",
+                "ts": "2025-10-04T10:30:00Z",
+                "type": "IDENTIFY"
+            }
+            """.trimIndent()
+
+        webTestClient
+            .post()
+            .uri("/cdp/ingest")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(eventJson)
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .expectBody()
+            .jsonPath("$.status")
+            .isEqualTo("error")
+            .jsonPath("$.message")
+            .value<String> { it.contains("At least one of") }
+
+        coVerify(exactly = 0) { mockEventBus.publish(any()) }
+    }
+
+    @Test
+    fun `should reject event with empty eventId`() {
+        val eventJson =
+            """
+            {
+                "eventId": "",
+                "ts": "2025-10-04T10:30:00Z",
+                "type": "IDENTIFY",
+                "userId": "user-123"
+            }
+            """.trimIndent()
+
+        webTestClient
+            .post()
+            .uri("/cdp/ingest")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(eventJson)
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .expectBody()
+            .jsonPath("$.status")
+            .isEqualTo("error")
+            .jsonPath("$.message")
+            .value<String> { it.contains("eventId is required") }
+
+        coVerify(exactly = 0) { mockEventBus.publish(any()) }
+    }
+
+    @Test
+    fun `should reject malformed JSON`() {
+        val eventJson = """{"eventId": "evt-123", "ts": "invalid"}"""
+
+        webTestClient
+            .post()
+            .uri("/cdp/ingest")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(eventJson)
+            .exchange()
+            .expectStatus()
+            .is4xxClientError
+
+        coVerify(exactly = 0) { mockEventBus.publish(any()) }
+    }
+
+    @Test
+    fun `should publish event to bus on successful ingestion`() =
+        runBlocking {
+            val event =
+                CdpEvent(
+                    eventId = "evt-success",
+                    ts = Instant.parse("2025-10-04T14:00:00Z"),
+                    type = CdpEventType.IDENTIFY,
+                    userId = "user-999",
+                    traits = mapOf("plan" to "pro"),
+                )
+
+            coEvery { mockEventBus.publish(event) } returns Unit
+
+            val eventJson = objectMapper.writeValueAsString(event)
+
+            webTestClient
+                .post()
+                .uri("/cdp/ingest")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(eventJson)
+                .exchange()
+                .expectStatus()
+                .isAccepted
+
+            coVerify { mockEventBus.publish(any()) }
+        }
+}

--- a/backend/src/test/kotlin/com/pulseboard/cdp/model/CdpModelsTest.kt
+++ b/backend/src/test/kotlin/com/pulseboard/cdp/model/CdpModelsTest.kt
@@ -1,0 +1,196 @@
+package com.pulseboard.cdp.model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class CdpModelsTest {
+    private val objectMapper =
+        ObjectMapper().apply {
+            registerModule(KotlinModule.Builder().build())
+            registerModule(JavaTimeModule())
+        }
+
+    @Test
+    fun `CdpEvent should serialize and deserialize correctly with all fields`() {
+        val event =
+            CdpEvent(
+                eventId = "evt-123",
+                ts = Instant.parse("2025-10-04T10:30:00Z"),
+                type = CdpEventType.TRACK,
+                anonymousId = "anon-456",
+                userId = "user-789",
+                email = "test@example.com",
+                name = "Feature Used",
+                properties = mapOf("feature" to "dashboard", "count" to 5),
+                traits = mapOf("plan" to "pro", "country" to "US"),
+            )
+
+        val json = objectMapper.writeValueAsString(event)
+        assertNotNull(json)
+
+        val deserializedEvent: CdpEvent = objectMapper.readValue(json)
+        assertEquals(event, deserializedEvent)
+    }
+
+    @Test
+    fun `CdpEvent should serialize and deserialize with minimal fields (IDENTIFY)`() {
+        val event =
+            CdpEvent(
+                eventId = "evt-456",
+                ts = Instant.parse("2025-10-04T11:00:00Z"),
+                type = CdpEventType.IDENTIFY,
+                userId = "user-123",
+            )
+
+        val json = objectMapper.writeValueAsString(event)
+        assertNotNull(json)
+
+        val deserializedEvent: CdpEvent = objectMapper.readValue(json)
+        assertEquals(event, deserializedEvent)
+        assertEquals(null, deserializedEvent.anonymousId)
+        assertEquals(null, deserializedEvent.email)
+        assertEquals(null, deserializedEvent.name)
+        assertEquals(emptyMap(), deserializedEvent.properties)
+        assertEquals(emptyMap(), deserializedEvent.traits)
+    }
+
+    @Test
+    fun `CdpEvent should serialize and deserialize with ALIAS type`() {
+        val event =
+            CdpEvent(
+                eventId = "evt-789",
+                ts = Instant.parse("2025-10-04T12:00:00Z"),
+                type = CdpEventType.ALIAS,
+                anonymousId = "anon-999",
+                userId = "user-888",
+            )
+
+        val json = objectMapper.writeValueAsString(event)
+        assertNotNull(json)
+
+        val deserializedEvent: CdpEvent = objectMapper.readValue(json)
+        assertEquals(event, deserializedEvent)
+    }
+
+    @Test
+    fun `CdpEvent should accept ISO-8601 timestamp formats`() {
+        val jsonWithOffset = """
+            {
+                "eventId": "evt-001",
+                "ts": "2025-10-04T10:30:00.000+00:00",
+                "type": "IDENTIFY",
+                "userId": "user-001"
+            }
+        """.trimIndent()
+
+        val event: CdpEvent = objectMapper.readValue(jsonWithOffset)
+        assertNotNull(event)
+        assertEquals("evt-001", event.eventId)
+        assertEquals(CdpEventType.IDENTIFY, event.type)
+    }
+
+    @Test
+    fun `CdpEvent should require eventId`() {
+        val event =
+            CdpEvent(
+                eventId = "",
+                ts = Instant.now(),
+                type = CdpEventType.IDENTIFY,
+                userId = "user-123",
+            )
+        val exception = assertThrows<IllegalArgumentException> { event.validate() }
+        assertTrue(exception.message!!.contains("eventId is required"))
+    }
+
+    @Test
+    fun `CdpEvent should require at least one identifier`() {
+        val event =
+            CdpEvent(
+                eventId = "evt-123",
+                ts = Instant.now(),
+                type = CdpEventType.IDENTIFY,
+            )
+        val exception = assertThrows<IllegalArgumentException> { event.validate() }
+        assertTrue(exception.message!!.contains("At least one of anonymousId, userId, or email"))
+    }
+
+    @Test
+    fun `CdpEvent TRACK should require name`() {
+        val event =
+            CdpEvent(
+                eventId = "evt-123",
+                ts = Instant.now(),
+                type = CdpEventType.TRACK,
+                userId = "user-123",
+            )
+        val exception = assertThrows<IllegalArgumentException> { event.validate() }
+        assertTrue(exception.message!!.contains("TRACK events require a name"))
+    }
+
+    @Test
+    fun `CdpProfile should serialize and deserialize correctly`() {
+        val profile =
+            CdpProfile(
+                profileId = "profile-123",
+                identifiers =
+                    ProfileIdentifiers(
+                        userIds = setOf("user-1", "user-2"),
+                        emails = setOf("user@example.com"),
+                        anonymousIds = setOf("anon-1", "anon-2"),
+                    ),
+                traits = mapOf("plan" to "pro", "country" to "US"),
+                counters = mapOf("Feature Used" to 10L, "Login" to 5L),
+                segments = setOf("power_user", "pro_plan"),
+                lastSeen = Instant.parse("2025-10-04T14:00:00Z"),
+            )
+
+        val json = objectMapper.writeValueAsString(profile)
+        assertNotNull(json)
+
+        val deserializedProfile: CdpProfile = objectMapper.readValue(json)
+        assertEquals(profile, deserializedProfile)
+    }
+
+    @Test
+    fun `CdpProfile should serialize and deserialize with minimal fields`() {
+        val profile =
+            CdpProfile(
+                profileId = "profile-456",
+                identifiers = ProfileIdentifiers(),
+                lastSeen = Instant.parse("2025-10-04T15:00:00Z"),
+            )
+
+        val json = objectMapper.writeValueAsString(profile)
+        assertNotNull(json)
+
+        val deserializedProfile: CdpProfile = objectMapper.readValue(json)
+        assertEquals(profile, deserializedProfile)
+        assertEquals(emptySet(), deserializedProfile.identifiers.userIds)
+        assertEquals(emptySet(), deserializedProfile.identifiers.emails)
+        assertEquals(emptySet(), deserializedProfile.identifiers.anonymousIds)
+        assertEquals(emptyMap(), deserializedProfile.traits)
+        assertEquals(emptyMap(), deserializedProfile.counters)
+        assertEquals(emptySet(), deserializedProfile.segments)
+    }
+
+    @Test
+    fun `CdpEventType enum should serialize and deserialize correctly`() {
+        val types = listOf(CdpEventType.IDENTIFY, CdpEventType.TRACK, CdpEventType.ALIAS)
+
+        types.forEach { type ->
+            val json = objectMapper.writeValueAsString(type)
+            assertNotNull(json)
+
+            val deserializedType: CdpEventType = objectMapper.readValue(json)
+            assertEquals(type, deserializedType)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements K1 from EPIC K — CDP Core (Backend). Adds CDP event/profile models and exposes `POST /cdp/ingest` endpoint for event ingestion.

## Deliverables

✅ `backend/src/main/kotlin/com/pulseboard/cdp/model/CdpEvent.kt`:
- Fields: `eventId`, `ts`, `type` (IDENTIFY/TRACK/ALIAS), `anonymousId`, `userId`, `email`, `name`, `properties`, `traits`
- Jackson ISO-8601 instant support via JavaTimeModule
- Validation method for CDP requirements

✅ `backend/src/main/kotlin/com/pulseboard/cdp/model/CdpProfile.kt`:
- Fields: `profileId`, `identifiers` (userIds, emails, anonymousIds), `traits`, `counters`, `segments`, `lastSeen`

✅ `backend/src/main/kotlin/com/pulseboard/cdp/api/CdpIngestController.kt`:
- `POST /cdp/ingest` endpoint (application/json)
- Validates events and publishes to in-memory `MutableSharedFlow<CdpEvent>`
- Returns 202 Accepted on success, 400 Bad Request on validation failure

✅ Unit tests for model (de)serialization and controller validation (WebFlux slice)

## Acceptance Criteria (DoD)

- [x] curl with sample payload returns 202 and event appears on an in-mem probe subscriber
- [x] Failing validations return 400 with message

## Validation Rules

- `eventId` required (non-blank)
- `ts` required
- `TRACK` events require `name`
- At least one of `anonymousId`, `userId`, or `email` must be present

## Testing

All 18 tests passing:
- Model serialization/deserialization tests (10 tests)
- Controller validation tests (8 tests)

## Example Usage

```bash
# Valid TRACK event
curl -X POST http://localhost:8080/cdp/ingest \
  -H "Content-Type: application/json" \
  -d '{
    "eventId": "evt-123",
    "ts": "2025-10-04T10:30:00Z",
    "type": "TRACK",
    "userId": "user-123",
    "name": "Feature Used",
    "properties": {"feature": "dashboard"}
  }'

# Response: {"status":"accepted","eventId":"evt-123"}
```

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)