### PR TITLE
feat(cdp): K4 watermark + dedup

### DIFF
--- a/backend/src/main/kotlin/com/pulseboard/cdp/runtime/CdpEventProcessor.kt
+++ b/backend/src/main/kotlin/com/pulseboard/cdp/runtime/CdpEventProcessor.kt
@@ -1,0 +1,292 @@
+package com.pulseboard.cdp.runtime
+
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.pulseboard.cdp.model.CdpEvent
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.time.Instant
+import java.util.PriorityQueue
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Event processor with watermark-based out-of-order handling and deduplication.
+ *
+ * Features:
+ * - Per-profile priority queue (min-heap by timestamp)
+ * - Bounded lateness with watermark (allowedLateness=120s)
+ * - Global ticker (1s) to drain and process events <= watermark
+ * - Deduplication via Caffeine cache (TTL=10m per profile)
+ * - Micrometer metrics
+ */
+class CdpEventProcessor(
+    private val allowedLateness: Duration = Duration.ofSeconds(120),
+    private val dedupTtl: Duration = Duration.ofMinutes(10),
+    private val tickerInterval: Duration = Duration.ofSeconds(1),
+    meterRegistry: MeterRegistry? = null
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    // Per-profile priority queues (min-heap by timestamp)
+    private val eventQueues = ConcurrentHashMap<String, PriorityQueue<CdpEvent>>()
+
+    // Per-profile deduplication caches
+    private val dedupCaches = ConcurrentHashMap<String, Cache<String, Boolean>>()
+
+    // Watermark state
+    @Volatile
+    private var currentWatermark: Instant = Instant.now().minus(allowedLateness)
+
+    // Metrics
+    private val bufferedEventsGauge = AtomicLong(0)
+    private val processedCounter = AtomicLong(0)
+    private val dedupHitsCounter = AtomicLong(0)
+    private val watermarkLagGauge = AtomicLong(0)
+
+    // Processed event handler
+    private var eventHandler: ((CdpEvent) -> Unit)? = null
+
+    // Ticker job
+    private var tickerJob: kotlinx.coroutines.Job? = null
+    private val scope = CoroutineScope(Dispatchers.Default)
+
+    init {
+        // Register metrics if registry provided
+        meterRegistry?.let { registry ->
+            Gauge.builder("cdp.events.buffered", bufferedEventsGauge) { it.get().toDouble() }
+                .description("Number of events currently buffered")
+                .register(registry)
+
+            Counter.builder("cdp.events.processed")
+                .description("Total number of events processed")
+                .register(registry)
+                .also { counter ->
+                    // Sync counter with internal counter
+                    scope.launch {
+                        var lastValue = 0L
+                        while (isActive) {
+                            val currentValue = processedCounter.get()
+                            val delta = currentValue - lastValue
+                            if (delta > 0) {
+                                counter.increment(delta.toDouble())
+                                lastValue = currentValue
+                            }
+                            delay(1000)
+                        }
+                    }
+                }
+
+            Counter.builder("cdp.events.dedup_hits")
+                .description("Number of duplicate events detected")
+                .register(registry)
+                .also { counter ->
+                    scope.launch {
+                        var lastValue = 0L
+                        while (isActive) {
+                            val currentValue = dedupHitsCounter.get()
+                            val delta = currentValue - lastValue
+                            if (delta > 0) {
+                                counter.increment(delta.toDouble())
+                                lastValue = currentValue
+                            }
+                            delay(1000)
+                        }
+                    }
+                }
+
+            Gauge.builder("cdp.watermark.lag_ms", watermarkLagGauge) { it.get().toDouble() }
+                .description("Watermark lag in milliseconds")
+                .register(registry)
+        }
+    }
+
+    /**
+     * Set the event handler to be called for each processed event.
+     */
+    fun onEvent(handler: (CdpEvent) -> Unit) {
+        this.eventHandler = handler
+    }
+
+    /**
+     * Submit an event for processing.
+     * The event will be buffered and processed when the watermark advances.
+     */
+    fun submit(event: CdpEvent, profileId: String) {
+        // Check for duplicate
+        val dedupCache = getDedupCache(profileId)
+        if (dedupCache.getIfPresent(event.eventId) != null) {
+            dedupHitsCounter.incrementAndGet()
+            logger.debug("Duplicate event detected: eventId={}, profileId={}", event.eventId, profileId)
+            return
+        }
+
+        // Mark as seen
+        dedupCache.put(event.eventId, true)
+
+        // Add to priority queue
+        val queue = getOrCreateQueue(profileId)
+        synchronized(queue) {
+            queue.offer(event)
+            bufferedEventsGauge.incrementAndGet()
+        }
+
+        logger.debug("Event buffered: eventId={}, profileId={}, ts={}", event.eventId, profileId, event.ts)
+    }
+
+    /**
+     * Start the watermark ticker.
+     * The ticker advances the watermark and drains processable events.
+     */
+    fun start() {
+        if (tickerJob?.isActive == true) {
+            logger.warn("Ticker already running")
+            return
+        }
+
+        tickerJob = scope.launch {
+            logger.info("Starting watermark ticker with interval={}", tickerInterval)
+            while (isActive) {
+                try {
+                    tick()
+                    delay(tickerInterval.toMillis())
+                } catch (e: Exception) {
+                    logger.error("Error in watermark ticker", e)
+                }
+            }
+        }
+    }
+
+    /**
+     * Stop the watermark ticker.
+     */
+    fun stop() {
+        tickerJob?.cancel()
+        tickerJob = null
+        logger.info("Watermark ticker stopped")
+    }
+
+    /**
+     * Perform a single tick: advance watermark and drain events.
+     */
+    fun tick() {
+        // Advance watermark
+        val now = Instant.now()
+        currentWatermark = now.minus(allowedLateness)
+
+        // Update watermark lag metric
+        val lag = Duration.between(currentWatermark, now).toMillis()
+        watermarkLagGauge.set(lag)
+
+        logger.debug("Watermark advanced to: {} (lag={}ms)", currentWatermark, lag)
+
+        // Drain events from all queues
+        eventQueues.forEach { (profileId, queue) ->
+            drainQueue(profileId, queue)
+        }
+    }
+
+    /**
+     * Drain events from a queue that are <= watermark.
+     */
+    private fun drainQueue(profileId: String, queue: PriorityQueue<CdpEvent>) {
+        val drained = mutableListOf<CdpEvent>()
+
+        synchronized(queue) {
+            while (queue.isNotEmpty()) {
+                val event = queue.peek()
+                if (event.ts <= currentWatermark) {
+                    queue.poll()
+                    drained.add(event)
+                    bufferedEventsGauge.decrementAndGet()
+                } else {
+                    break
+                }
+            }
+        }
+
+        // Process drained events in order
+        drained.forEach { event ->
+            processEvent(event, profileId)
+        }
+
+        if (drained.isNotEmpty()) {
+            logger.debug("Drained {} events for profileId={}", drained.size, profileId)
+        }
+    }
+
+    /**
+     * Process a single event.
+     */
+    private fun processEvent(event: CdpEvent, profileId: String) {
+        processedCounter.incrementAndGet()
+        logger.debug("Processing event: eventId={}, profileId={}, ts={}", event.eventId, profileId, event.ts)
+
+        // Call handler if registered
+        eventHandler?.invoke(event)
+    }
+
+    /**
+     * Get or create a priority queue for a profile.
+     */
+    private fun getOrCreateQueue(profileId: String): PriorityQueue<CdpEvent> {
+        return eventQueues.computeIfAbsent(profileId) {
+            PriorityQueue(compareBy { it.ts })
+        }
+    }
+
+    /**
+     * Get or create a dedup cache for a profile.
+     */
+    private fun getDedupCache(profileId: String): Cache<String, Boolean> {
+        return dedupCaches.computeIfAbsent(profileId) {
+            Caffeine.newBuilder()
+                .expireAfterWrite(dedupTtl.toMillis(), TimeUnit.MILLISECONDS)
+                .maximumSize(10000)
+                .build()
+        }
+    }
+
+    /**
+     * Get current watermark (for testing).
+     */
+    fun getCurrentWatermark(): Instant = currentWatermark
+
+    /**
+     * Get buffered event count.
+     */
+    fun getBufferedEventCount(): Long = bufferedEventsGauge.get()
+
+    /**
+     * Get processed event count.
+     */
+    fun getProcessedEventCount(): Long = processedCounter.get()
+
+    /**
+     * Get dedup hits count.
+     */
+    fun getDedupHitsCount(): Long = dedupHitsCounter.get()
+
+    /**
+     * Clear all state (for testing).
+     */
+    fun clear() {
+        stop()
+        eventQueues.clear()
+        dedupCaches.clear()
+        bufferedEventsGauge.set(0)
+        processedCounter.set(0)
+        dedupHitsCounter.set(0)
+        watermarkLagGauge.set(0)
+        currentWatermark = Instant.now().minus(allowedLateness)
+    }
+}

--- a/backend/src/test/kotlin/com/pulseboard/cdp/runtime/CdpEventProcessorTest.kt
+++ b/backend/src/test/kotlin/com/pulseboard/cdp/runtime/CdpEventProcessorTest.kt
@@ -1,0 +1,353 @@
+package com.pulseboard.cdp.runtime
+
+import com.pulseboard.cdp.model.CdpEvent
+import com.pulseboard.cdp.model.CdpEventType
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CdpEventProcessorTest {
+    private lateinit var processor: CdpEventProcessor
+    private val processedEvents = mutableListOf<CdpEvent>()
+
+    @BeforeEach
+    fun setup() {
+        processor = CdpEventProcessor(
+            allowedLateness = Duration.ofSeconds(120),
+            dedupTtl = Duration.ofMinutes(10)
+        )
+        processedEvents.clear()
+
+        // Set up event handler to capture processed events
+        processor.onEvent { event ->
+            processedEvents.add(event)
+        }
+    }
+
+    @AfterEach
+    fun teardown() {
+        processor.stop()
+        processor.clear()
+    }
+
+    // === Out-of-Order Processing Tests (DoD Requirement) ===
+
+    @Test
+    fun `shuffled sequence should process in timestamp order`() = runBlocking {
+        val profileId = "profile-1"
+        // Make events old enough to be immediately processed (beyond watermark)
+        val baseTime = Instant.now().minusSeconds(200)
+
+        // Create events with timestamps in random order
+        val events = listOf(
+            createEvent("evt-3", baseTime.plusSeconds(30)),
+            createEvent("evt-1", baseTime.plusSeconds(10)),
+            createEvent("evt-5", baseTime.plusSeconds(50)),
+            createEvent("evt-2", baseTime.plusSeconds(20)),
+            createEvent("evt-4", baseTime.plusSeconds(40))
+        )
+
+        // Submit in shuffled order
+        events.forEach { processor.submit(it, profileId) }
+
+        // Run ticker to process events
+        processor.tick()
+
+        // Verify events processed in timestamp order
+        assertEquals(5, processedEvents.size)
+        assertEquals("evt-1", processedEvents[0].eventId)
+        assertEquals("evt-2", processedEvents[1].eventId)
+        assertEquals("evt-3", processedEvents[2].eventId)
+        assertEquals("evt-4", processedEvents[3].eventId)
+        assertEquals("evt-5", processedEvents[4].eventId)
+
+        // Verify timestamps are in ascending order
+        for (i in 1 until processedEvents.size) {
+            assertTrue(processedEvents[i - 1].ts <= processedEvents[i].ts)
+        }
+    }
+
+    @Test
+    fun `events should be buffered until watermark advances`() = runBlocking {
+        val profileId = "profile-1"
+        val now = Instant.now()
+
+        // Create event in the future (within allowed lateness)
+        val futureEvent = createEvent("evt-future", now.minusSeconds(60))
+
+        processor.submit(futureEvent, profileId)
+
+        // Should be buffered, not processed yet
+        assertEquals(1, processor.getBufferedEventCount())
+        assertEquals(0, processedEvents.size)
+
+        // Advance watermark
+        processor.tick()
+
+        // Should still be buffered (watermark is now - 120s, event is now - 60s)
+        assertEquals(1, processor.getBufferedEventCount())
+        assertEquals(0, processedEvents.size)
+
+        // Wait for watermark to catch up
+        delay(100)
+        // Manually set older event
+        val oldEvent = createEvent("evt-old", now.minusSeconds(150))
+        processor.submit(oldEvent, profileId)
+        processor.tick()
+
+        // Old event should be processed
+        assertEquals(1, processedEvents.size)
+        assertEquals("evt-old", processedEvents[0].eventId)
+    }
+
+    @Test
+    fun `watermark should drain events older than allowed lateness`() = runBlocking {
+        val profileId = "profile-1"
+        val baseTime = Instant.now().minusSeconds(200)
+
+        // Create events well before watermark
+        val oldEvents = listOf(
+            createEvent("evt-1", baseTime),
+            createEvent("evt-2", baseTime.plusSeconds(10)),
+            createEvent("evt-3", baseTime.plusSeconds(20))
+        )
+
+        oldEvents.forEach { processor.submit(it, profileId) }
+
+        // All should be buffered
+        assertEquals(3, processor.getBufferedEventCount())
+
+        // Tick to drain
+        processor.tick()
+
+        // All should be processed
+        assertEquals(0, processor.getBufferedEventCount())
+        assertEquals(3, processedEvents.size)
+        assertEquals(3, processor.getProcessedEventCount())
+    }
+
+    // === Duplicate Detection Tests (DoD Requirement) ===
+
+    @Test
+    fun `duplicate eventId should be ignored`() = runBlocking {
+        val profileId = "profile-1"
+        val baseTime = Instant.now().minusSeconds(150)
+
+        val event1 = createEvent("evt-duplicate", baseTime)
+        val event2 = createEvent("evt-duplicate", baseTime.plusSeconds(10)) // Same ID, different timestamp
+
+        processor.submit(event1, profileId)
+        processor.submit(event2, profileId) // Should be ignored
+
+        processor.tick()
+
+        // Only first event should be processed
+        assertEquals(1, processedEvents.size)
+        assertEquals("evt-duplicate", processedEvents[0].eventId)
+        assertEquals(1, processor.getDedupHitsCount())
+    }
+
+    @Test
+    fun `multiple duplicates should all be ignored`() = runBlocking {
+        val profileId = "profile-1"
+        val baseTime = Instant.now().minusSeconds(150)
+
+        val event = createEvent("evt-dup", baseTime)
+
+        // Submit same event 5 times
+        repeat(5) {
+            processor.submit(event, profileId)
+        }
+
+        processor.tick()
+
+        // Only one should be processed
+        assertEquals(1, processedEvents.size)
+        assertEquals(4, processor.getDedupHitsCount())
+    }
+
+    @Test
+    fun `duplicates across different profiles should be allowed`() = runBlocking {
+        val baseTime = Instant.now().minusSeconds(150)
+
+        val event = createEvent("evt-shared", baseTime)
+
+        // Submit to different profiles
+        processor.submit(event, "profile-1")
+        processor.submit(event, "profile-2")
+        processor.submit(event, "profile-3")
+
+        processor.tick()
+
+        // All should be processed (different profiles)
+        assertEquals(3, processedEvents.size)
+        assertEquals(0, processor.getDedupHitsCount())
+    }
+
+    // === Watermark Tests ===
+
+    @Test
+    fun `watermark should be computed as now minus allowed lateness`() {
+        val before = Instant.now().minus(Duration.ofSeconds(120))
+        processor.tick()
+        val after = Instant.now().minus(Duration.ofSeconds(120))
+
+        val watermark = processor.getCurrentWatermark()
+
+        assertTrue(watermark >= before)
+        assertTrue(watermark <= after)
+    }
+
+    @Test
+    fun `watermark should advance on each tick`() = runBlocking {
+        processor.tick()
+        val watermark1 = processor.getCurrentWatermark()
+
+        delay(100)
+
+        processor.tick()
+        val watermark2 = processor.getCurrentWatermark()
+
+        assertTrue(watermark2 > watermark1)
+    }
+
+    // === Per-Profile Isolation Tests ===
+
+    @Test
+    fun `events from different profiles should be processed independently`() = runBlocking {
+        val baseTime = Instant.now().minusSeconds(150)
+
+        // Submit events for different profiles
+        processor.submit(createEvent("evt-p1-1", baseTime), "profile-1")
+        processor.submit(createEvent("evt-p2-1", baseTime.plusSeconds(5)), "profile-2")
+        processor.submit(createEvent("evt-p1-2", baseTime.plusSeconds(10)), "profile-1")
+        processor.submit(createEvent("evt-p2-2", baseTime.plusSeconds(15)), "profile-2")
+
+        processor.tick()
+
+        // All should be processed
+        assertEquals(4, processedEvents.size)
+
+        // Each profile's events should be in order
+        val p1Events = processedEvents.filter { it.eventId.contains("p1") }
+        val p2Events = processedEvents.filter { it.eventId.contains("p2") }
+
+        assertEquals(2, p1Events.size)
+        assertEquals(2, p2Events.size)
+
+        assertTrue(p1Events[0].ts < p1Events[1].ts)
+        assertTrue(p2Events[0].ts < p2Events[1].ts)
+    }
+
+    // === Metrics Tests ===
+
+    @Test
+    fun `metrics should track buffered and processed events`() = runBlocking {
+        val meterRegistry = SimpleMeterRegistry()
+        val metricsProcessor = CdpEventProcessor(meterRegistry = meterRegistry)
+
+        val profileId = "profile-1"
+        val baseTime = Instant.now().minusSeconds(150)
+
+        // Submit events
+        metricsProcessor.submit(createEvent("evt-1", baseTime), profileId)
+        metricsProcessor.submit(createEvent("evt-2", baseTime.plusSeconds(10)), profileId)
+
+        assertEquals(2, metricsProcessor.getBufferedEventCount())
+        assertEquals(0, metricsProcessor.getProcessedEventCount())
+
+        // Process
+        metricsProcessor.tick()
+
+        assertEquals(0, metricsProcessor.getBufferedEventCount())
+        assertEquals(2, metricsProcessor.getProcessedEventCount())
+
+        metricsProcessor.clear()
+    }
+
+    @Test
+    fun `metrics should track dedup hits`() = runBlocking {
+        val profileId = "profile-1"
+        val baseTime = Instant.now().minusSeconds(150)
+
+        val event = createEvent("evt-dup", baseTime)
+
+        processor.submit(event, profileId)
+        processor.submit(event, profileId)
+        processor.submit(event, profileId)
+
+        assertEquals(2, processor.getDedupHitsCount())
+    }
+
+    // === Complex Scenario Tests ===
+
+    @Test
+    fun `complex scenario with mixed timestamps and duplicates`() = runBlocking {
+        val profileId = "profile-1"
+        val baseTime = Instant.now().minusSeconds(180)
+
+        // Create a complex sequence with out-of-order and duplicates
+        val events = listOf(
+            createEvent("evt-1", baseTime.plusSeconds(10)),
+            createEvent("evt-3", baseTime.plusSeconds(30)),
+            createEvent("evt-1", baseTime.plusSeconds(10)), // Duplicate
+            createEvent("evt-2", baseTime.plusSeconds(20)),
+            createEvent("evt-5", baseTime.plusSeconds(50)),
+            createEvent("evt-4", baseTime.plusSeconds(40)),
+            createEvent("evt-3", baseTime.plusSeconds(30)), // Duplicate
+        )
+
+        events.forEach { processor.submit(it, profileId) }
+
+        processor.tick()
+
+        // Should have 5 unique events processed in order
+        assertEquals(5, processedEvents.size)
+        assertEquals(2, processor.getDedupHitsCount())
+
+        // Verify order
+        assertEquals("evt-1", processedEvents[0].eventId)
+        assertEquals("evt-2", processedEvents[1].eventId)
+        assertEquals("evt-3", processedEvents[2].eventId)
+        assertEquals("evt-4", processedEvents[3].eventId)
+        assertEquals("evt-5", processedEvents[4].eventId)
+    }
+
+    @Test
+    fun `ticker should continuously process events when started`() = runBlocking {
+        processor.start()
+
+        val profileId = "profile-1"
+        val baseTime = Instant.now().minusSeconds(150)
+
+        // Submit events
+        processor.submit(createEvent("evt-1", baseTime), profileId)
+
+        // Wait for ticker to process
+        delay(1500) // Wait for at least one tick
+
+        // Event should be processed
+        assertTrue(processedEvents.isNotEmpty())
+
+        processor.stop()
+    }
+
+    // === Helper Functions ===
+
+    private fun createEvent(eventId: String, ts: Instant): CdpEvent {
+        return CdpEvent(
+            eventId = eventId,
+            ts = ts,
+            type = CdpEventType.TRACK,
+            userId = "user-123",
+            name = "test_event"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Implements K4 from EPIC K — CDP Core (Backend). Adds event-time buffer with watermark-based processing and deduplication for handling out-of-order events per profile.

## Deliverables

✅ `backend/src/main/kotlin/com/pulseboard/cdp/runtime/CdpEventProcessor.kt`:
- Per-profile priority queues (min-heap by timestamp)
- Bounded lateness: `allowedLateness = 120s` (configurable)
- Global watermark ticker (1s interval)
- Watermark computation: `watermark = now() - allowedLateness`
- Automatic event draining when `ts <= watermark`
- In-order processing within each profile

✅ Deduplication:
- Per-profile Caffeine cache: `Cache<eventId, Boolean>`
- TTL: 10 minutes (configurable)
- Maximum size: 10,000 entries per profile
- Duplicate events logged and counted

✅ Micrometer metrics:
- `cdp.events.buffered` (gauge) - Events currently in queues
- `cdp.events.processed` (counter) - Total processed events
- `cdp.events.dedup_hits` (counter) - Duplicate detections
- `cdp.watermark.lag_ms` (gauge) - Watermark lag in milliseconds

✅ Comprehensive unit tests (13 tests)

## Acceptance Criteria (DoD)

- [x] Tests: shuffled sequence processes in timestamp order
- [x] Tests: duplicate eventId ignored per profile

## Implementation Details

### Watermark Processing

```kotlin
// Watermark = now - allowedLateness
currentWatermark = Instant.now().minus(Duration.ofSeconds(120))

// Drain events from priority queues where ts <= watermark
while (queue.peek().ts <= currentWatermark) {
    processEvent(queue.poll())
}
```

### Per-Profile Isolation

- Separate priority queue per profileId
- Separate dedup cache per profileId
- Events from different profiles processed independently
- Ensures no cross-profile interference

### Ticker

- Runs every 1 second (configurable)
- Advances watermark: `now() - allowedLateness`
- Drains all queues for processable events
- Can be started/stopped independently

## Testing

All 147 tests passing (13 new K4 tests):
- ✅ Out-of-order processing (shuffled sequences)
- ✅ Duplicate detection and suppression
- ✅ Watermark advancement
- ✅ Per-profile isolation
- ✅ Metrics tracking
- ✅ Ticker functionality
- ✅ Complex scenarios (mixed timestamps + duplicates)

## Example Usage

```kotlin
val processor = CdpEventProcessor(
    allowedLateness = Duration.ofSeconds(120),
    dedupTtl = Duration.ofMinutes(10),
    meterRegistry = meterRegistry
)

// Register event handler
processor.onEvent { event ->
    // Process event in timestamp order
}

// Start ticker
processor.start()

// Submit events (can arrive out of order)
processor.submit(event1, "profile-123")
processor.submit(event2, "profile-123")

// Events buffered until watermark advances
// Then drained and processed in timestamp order
```

## Configuration

| Parameter | Default | Description |
|-----------|---------|-------------|
| `allowedLateness` | 120s | Max event lateness |
| `dedupTtl` | 10m | Dedup cache TTL |
| `tickerInterval` | 1s | Watermark tick rate |

## Dependencies

**Blocked by:** 
- #43 (K1) ✅ Merged
- #44 (K2) ✅ Merged  
- #45 (K3) - Pending

**Blocks:** #47 (K5)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)