### PR TITLE
feat(ui): L5 CDP KPIs and sparkline

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pulseboard - Real-time Anomaly Detection</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/components/CdpKpiPanel.tsx
+++ b/ui/src/components/CdpKpiPanel.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useRef } from 'react';
+import { useCdpKpis } from '../lib/useCdpKpis';
+
+interface CdpKpiPanelProps {
+  isSimulatorRunning: boolean;
+}
+
+declare global {
+  interface Window {
+    Chart: any;
+  }
+}
+
+export function CdpKpiPanel({ isSimulatorRunning }: CdpKpiPanelProps) {
+  const kpis = useCdpKpis(isSimulatorRunning);
+  const chartRef = useRef<HTMLCanvasElement>(null);
+  const chartInstanceRef = useRef<any>(null);
+
+  // Initialize Chart.js sparkline
+  useEffect(() => {
+    if (!chartRef.current || typeof window.Chart === 'undefined') return;
+
+    const ctx = chartRef.current.getContext('2d');
+    if (!ctx) return;
+
+    // Destroy existing chart if any
+    if (chartInstanceRef.current) {
+      chartInstanceRef.current.destroy();
+    }
+
+    // Create new chart
+    chartInstanceRef.current = new window.Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: Array(120).fill(''), // 120 data points (2 minutes at 1s intervals)
+        datasets: [
+          {
+            label: 'Segment ENTERs/min',
+            data: kpis.segmentEntersHistory,
+            borderColor: '#3b82f6',
+            backgroundColor: 'rgba(59, 130, 246, 0.1)',
+            borderWidth: 2,
+            fill: true,
+            tension: 0.4,
+            pointRadius: 0,
+            pointHoverRadius: 0,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: {
+          duration: 0, // Disable animation to avoid jank
+        },
+        scales: {
+          x: {
+            display: false,
+          },
+          y: {
+            beginAtZero: true,
+            ticks: {
+              font: {
+                size: 10,
+              },
+              color: '#6b7280',
+            },
+            grid: {
+              color: '#e5e7eb',
+            },
+          },
+        },
+        plugins: {
+          legend: {
+            display: false,
+          },
+          tooltip: {
+            enabled: false,
+          },
+        },
+      },
+    });
+
+    return () => {
+      if (chartInstanceRef.current) {
+        chartInstanceRef.current.destroy();
+      }
+    };
+  }, []); // Only initialize once
+
+  // Update chart data
+  useEffect(() => {
+    if (!chartInstanceRef.current) return;
+
+    // Use requestAnimationFrame to avoid reflow
+    requestAnimationFrame(() => {
+      if (chartInstanceRef.current) {
+        chartInstanceRef.current.data.datasets[0].data = kpis.segmentEntersHistory;
+        chartInstanceRef.current.update('none'); // Update without animation
+      }
+    });
+  }, [kpis.segmentEntersHistory]);
+
+  // Simulator not running state
+  if (!isSimulatorRunning) {
+    return (
+      <div
+        style={{
+          backgroundColor: 'white',
+          borderRadius: '0.5rem',
+          padding: '1.5rem',
+          boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+          border: '1px solid #e2e8f0',
+        }}
+      >
+        <div style={{ textAlign: 'center', color: '#6b7280' }}>
+          <div style={{ fontSize: '0.875rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+            CDP Metrics
+          </div>
+          <div style={{ fontSize: '0.75rem' }}>
+            Start the simulator to see real-time KPIs
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        backgroundColor: 'white',
+        borderRadius: '0.5rem',
+        padding: '1.5rem',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+        border: '1px solid #e2e8f0',
+      }}
+    >
+      {/* KPI Cards */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          gap: '1rem',
+          marginBottom: '1.5rem',
+        }}
+      >
+        {/* Active Profiles */}
+        <div
+          style={{
+            padding: '1rem',
+            backgroundColor: '#f9fafb',
+            borderRadius: '0.5rem',
+            border: '1px solid #e5e7eb',
+          }}
+        >
+          <div
+            style={{
+              fontSize: '0.75rem',
+              fontWeight: '600',
+              color: '#6b7280',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              marginBottom: '0.5rem',
+            }}
+          >
+            Active Profiles (5m)
+          </div>
+          <div
+            style={{
+              fontSize: '1.875rem',
+              fontWeight: '700',
+              color: '#111827',
+            }}
+          >
+            {kpis.activeProfiles}
+          </div>
+        </div>
+
+        {/* Events/min */}
+        <div
+          style={{
+            padding: '1rem',
+            backgroundColor: '#f9fafb',
+            borderRadius: '0.5rem',
+            border: '1px solid #e5e7eb',
+          }}
+        >
+          <div
+            style={{
+              fontSize: '0.75rem',
+              fontWeight: '600',
+              color: '#6b7280',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              marginBottom: '0.5rem',
+            }}
+          >
+            Events/min
+          </div>
+          <div
+            style={{
+              fontSize: '1.875rem',
+              fontWeight: '700',
+              color: '#111827',
+            }}
+          >
+            {kpis.eventsPerMinute.toFixed(1)}
+          </div>
+        </div>
+
+        {/* Segment ENTERs/min */}
+        <div
+          style={{
+            padding: '1rem',
+            backgroundColor: '#f9fafb',
+            borderRadius: '0.5rem',
+            border: '1px solid #e5e7eb',
+          }}
+        >
+          <div
+            style={{
+              fontSize: '0.75rem',
+              fontWeight: '600',
+              color: '#6b7280',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              marginBottom: '0.5rem',
+            }}
+          >
+            Segment ENTERs/min
+          </div>
+          <div
+            style={{
+              fontSize: '1.875rem',
+              fontWeight: '700',
+              color: '#3b82f6',
+            }}
+          >
+            {kpis.segmentEntersPerMinute.toFixed(1)}
+          </div>
+        </div>
+      </div>
+
+      {/* Sparkline */}
+      <div>
+        <div
+          style={{
+            fontSize: '0.75rem',
+            fontWeight: '600',
+            color: '#6b7280',
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+            marginBottom: '0.75rem',
+          }}
+        >
+          Segment ENTERs/min (Last 2 min)
+        </div>
+        <div style={{ height: '120px', position: 'relative' }}>
+          <canvas ref={chartRef} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/CdpTabs.tsx
+++ b/ui/src/components/CdpTabs.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ProfilesList } from './ProfilesList';
 import { SegmentFeed } from './SegmentFeed';
+import { CdpKpiPanel } from './CdpKpiPanel';
 
 type TabType = 'profiles' | 'segments';
 
@@ -12,15 +13,20 @@ export function CdpTabs({ isSimulatorRunning }: CdpTabsProps) {
   const [activeTab, setActiveTab] = useState<TabType>('profiles');
 
   return (
-    <div
-      style={{
-        backgroundColor: 'white',
-        borderRadius: '0.5rem',
-        boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
-        border: '1px solid #e2e8f0',
-        overflow: 'hidden',
-      }}
-    >
+    <>
+      {/* KPI Panel */}
+      <CdpKpiPanel isSimulatorRunning={isSimulatorRunning} />
+
+      {/* Tabs */}
+      <div
+        style={{
+          backgroundColor: 'white',
+          borderRadius: '0.5rem',
+          boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+          border: '1px solid #e2e8f0',
+          overflow: 'hidden',
+        }}
+      >
       {/* Tab Headers */}
       <div
         style={{
@@ -71,5 +77,6 @@ export function CdpTabs({ isSimulatorRunning }: CdpTabsProps) {
         {activeTab === 'segments' && <SegmentFeed isSimulatorRunning={isSimulatorRunning} />}
       </div>
     </div>
+    </>
   );
 }

--- a/ui/src/lib/slidingWindow.test.ts
+++ b/ui/src/lib/slidingWindow.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { SlidingWindow, UniqueCountWindow } from './slidingWindow';
+
+describe('SlidingWindow', () => {
+
+  it('should add events to the window', () => {
+    const window = new SlidingWindow<{ timestamp: number }>(5000); // 5 second window
+
+    const now = Date.now();
+    window.add({ timestamp: now });
+    window.add({ timestamp: now + 1000 });
+
+    expect(window.count()).toBe(2);
+  });
+
+  it('should evict events older than the window', () => {
+    const window = new SlidingWindow<{ timestamp: number }>(5000); // 5 second window
+
+    const now = Date.now();
+
+    window.add({ timestamp: now - 10000 }); // 10s ago - should be evicted
+    window.add({ timestamp: now - 6000 }); // 6s ago - should be evicted
+    window.add({ timestamp: now - 2000 }); // 2s ago - should be kept
+
+    expect(window.count()).toBe(1);
+  });
+
+  it('should keep recent events within the window', () => {
+    const window = new SlidingWindow<{ timestamp: number }>(5000); // 5 second window
+
+    const now = Date.now();
+
+    window.add({ timestamp: now - 1000 }); // 1s ago - should be kept
+    window.add({ timestamp: now - 2000 }); // 2s ago - should be kept
+    window.add({ timestamp: now - 3000 }); // 3s ago - should be kept
+
+    expect(window.count()).toBe(3);
+  });
+
+  it('should calculate rate per minute correctly', () => {
+    const window = new SlidingWindow<{ timestamp: number }>(60000); // 1 minute window
+
+    const now = Date.now();
+
+    // Add 10 events in the window
+    for (let i = 0; i < 10; i++) {
+      window.add({ timestamp: now - i * 1000 });
+    }
+
+    // Rate should be 10 events / 1 minute = 10/min
+    expect(window.getRatePerMinute()).toBe(10);
+  });
+
+  it('should return zero rate for empty window', () => {
+    const window = new SlidingWindow<{ timestamp: number }>(60000);
+
+    expect(window.getRatePerMinute()).toBe(0);
+  });
+
+  it('should return all events in the window', () => {
+    const window = new SlidingWindow<{ timestamp: number; data: string }>(5000);
+
+    const now = Date.now();
+
+    window.add({ timestamp: now - 1000, data: 'event1' });
+    window.add({ timestamp: now - 2000, data: 'event2' });
+
+    const events = window.getEvents();
+    expect(events).toHaveLength(2);
+    expect(events[0].data).toBe('event1');
+    expect(events[1].data).toBe('event2');
+  });
+
+  it('should clear all events', () => {
+    const window = new SlidingWindow<{ timestamp: number }>(5000);
+
+    const now = Date.now();
+    window.add({ timestamp: now });
+    window.add({ timestamp: now + 1000 });
+
+    expect(window.count()).toBe(2);
+
+    window.clear();
+
+    expect(window.count()).toBe(0);
+  });
+});
+
+describe('UniqueCountWindow', () => {
+
+  it('should count unique keys', () => {
+    const window = new UniqueCountWindow<{ timestamp: number; key: string }>(5000);
+
+    const now = Date.now();
+
+    window.add({ timestamp: now - 1000, key: 'user1' });
+    window.add({ timestamp: now - 2000, key: 'user2' });
+    window.add({ timestamp: now - 3000, key: 'user1' }); // Duplicate key
+
+    expect(window.uniqueCount()).toBe(2); // Only 2 unique keys
+  });
+
+  it('should evict old events when counting unique keys', () => {
+    const window = new UniqueCountWindow<{ timestamp: number; key: string }>(5000);
+
+    const now = Date.now();
+
+    window.add({ timestamp: now - 10000, key: 'user1' }); // 10s ago - evicted
+    window.add({ timestamp: now - 6000, key: 'user2' }); // 6s ago - evicted
+    window.add({ timestamp: now - 2000, key: 'user3' }); // 2s ago - kept
+
+    expect(window.uniqueCount()).toBe(1);
+  });
+
+  it('should handle empty window', () => {
+    const window = new UniqueCountWindow<{ timestamp: number; key: string }>(5000);
+
+    expect(window.uniqueCount()).toBe(0);
+  });
+
+  it('should clear all events', () => {
+    const window = new UniqueCountWindow<{ timestamp: number; key: string }>(5000);
+
+    const now = Date.now();
+    window.add({ timestamp: now, key: 'user1' });
+    window.add({ timestamp: now + 1000, key: 'user2' });
+
+    expect(window.uniqueCount()).toBe(2);
+
+    window.clear();
+
+    expect(window.uniqueCount()).toBe(0);
+  });
+
+  it('should count only recent unique keys', () => {
+    const window = new UniqueCountWindow<{ timestamp: number; key: string }>(5000);
+
+    const now = Date.now();
+
+    window.add({ timestamp: now - 10000, key: 'user1' }); // Old - evicted
+    window.add({ timestamp: now - 2000, key: 'user2' }); // Recent - kept
+    window.add({ timestamp: now - 1000, key: 'user3' }); // Recent - kept
+
+    expect(window.uniqueCount()).toBe(2); // user2, user3
+  });
+});

--- a/ui/src/lib/slidingWindow.ts
+++ b/ui/src/lib/slidingWindow.ts
@@ -1,0 +1,108 @@
+/**
+ * Sliding window counter for computing time-based aggregations.
+ *
+ * Tracks timestamped events and computes counts/rates within a time window.
+ */
+
+export interface TimestampedEvent {
+  timestamp: number; // Unix timestamp in milliseconds
+}
+
+/**
+ * Sliding window that maintains events within a time window.
+ * Automatically evicts old events outside the window.
+ */
+export class SlidingWindow<T extends TimestampedEvent> {
+  private events: T[] = [];
+  private windowMs: number;
+
+  /**
+   * @param windowMs - Window size in milliseconds
+   */
+  constructor(windowMs: number) {
+    this.windowMs = windowMs;
+  }
+
+  /**
+   * Add an event to the window.
+   * Automatically evicts events older than the window.
+   */
+  add(event: T): void {
+    this.events.push(event);
+    this.evictOldEvents();
+  }
+
+  /**
+   * Get count of events in the current window.
+   */
+  count(): number {
+    this.evictOldEvents();
+    return this.events.length;
+  }
+
+  /**
+   * Get all events in the current window.
+   */
+  getEvents(): T[] {
+    this.evictOldEvents();
+    return [...this.events];
+  }
+
+  /**
+   * Get rate per minute for events in the window.
+   */
+  getRatePerMinute(): number {
+    this.evictOldEvents();
+    if (this.events.length === 0) return 0;
+
+    const windowMinutes = this.windowMs / 60000;
+    return this.events.length / windowMinutes;
+  }
+
+  /**
+   * Clear all events from the window.
+   */
+  clear(): void {
+    this.events = [];
+  }
+
+  /**
+   * Evict events older than the window.
+   */
+  private evictOldEvents(): void {
+    const now = Date.now();
+    const cutoff = now - this.windowMs;
+
+    // Remove events older than cutoff
+    this.events = this.events.filter(event => event.timestamp >= cutoff);
+  }
+}
+
+/**
+ * Count unique values within a sliding window.
+ * Useful for counting unique profiles, etc.
+ */
+export class UniqueCountWindow<T extends TimestampedEvent & { key: string }> {
+  private window: SlidingWindow<T>;
+
+  constructor(windowMs: number) {
+    this.window = new SlidingWindow(windowMs);
+  }
+
+  add(event: T): void {
+    this.window.add(event);
+  }
+
+  /**
+   * Get count of unique keys in the window.
+   */
+  uniqueCount(): number {
+    const events = this.window.getEvents();
+    const uniqueKeys = new Set(events.map(e => e.key));
+    return uniqueKeys.size;
+  }
+
+  clear(): void {
+    this.window.clear();
+  }
+}

--- a/ui/src/lib/useCdpKpis.ts
+++ b/ui/src/lib/useCdpKpis.ts
@@ -1,0 +1,124 @@
+import { useEffect, useState, useRef } from 'react';
+import { useCdpProfiles, type ProfileSummary } from './useCdpProfiles';
+import { useSegmentFeed, type SegmentEvent } from './useSegmentFeed';
+import { SlidingWindow, UniqueCountWindow } from './slidingWindow';
+
+/**
+ * CDP KPI metrics computed from real-time SSE streams.
+ */
+export interface CdpKpis {
+  activeProfiles: number; // Unique profiles active in last 5 minutes
+  eventsPerMinute: number; // Rate of all CDP events per minute
+  segmentEntersPerMinute: number; // Rate of ENTER events per minute
+  segmentEntersHistory: number[]; // Last N data points for sparkline
+}
+
+interface EventTimestamp {
+  timestamp: number;
+}
+
+interface ProfileEvent extends EventTimestamp {
+  key: string; // profileId
+}
+
+/**
+ * Hook for computing CDP KPIs from SSE streams.
+ *
+ * Subscribes to /sse/cdp/profiles and /sse/cdp/segments and computes:
+ * - Active profiles (unique profiles seen in last 5 minutes)
+ * - Events per minute (rate of all profile updates)
+ * - Segment ENTERs per minute (rate of ENTER events)
+ * - Sparkline data (ENTERs/min for last 2 minutes)
+ *
+ * Updates are throttled to ~1s to avoid jank.
+ *
+ * @param enabled - Whether to compute KPIs (tied to simulator running)
+ */
+export function useCdpKpis(enabled: boolean = true): CdpKpis {
+  // Subscribe to SSE streams
+  const { profiles } = useCdpProfiles(enabled);
+  const { events: segmentEvents } = useSegmentFeed(enabled);
+
+  // Sliding windows for KPI calculations
+  const profileWindow = useRef(new UniqueCountWindow<ProfileEvent>(5 * 60 * 1000)); // 5 min
+  const eventWindow = useRef(new SlidingWindow<EventTimestamp>(5 * 60 * 1000)); // 5 min
+  const enterWindow = useRef(new SlidingWindow<EventTimestamp>(5 * 60 * 1000)); // 5 min
+
+  // Sparkline data (last 2 minutes, 1 data point per second = 120 points)
+  const [sparklineData, setSparklineData] = useState<number[]>([]);
+
+  // Current KPIs (throttled updates)
+  const [kpis, setKpis] = useState<CdpKpis>({
+    activeProfiles: 0,
+    eventsPerMinute: 0,
+    segmentEntersPerMinute: 0,
+    segmentEntersHistory: [],
+  });
+
+  // Track profiles seen
+  useEffect(() => {
+    if (!enabled) return;
+
+    profiles.forEach((profile) => {
+      const timestamp = new Date(profile.lastSeen).getTime();
+      profileWindow.current.add({
+        key: profile.profileId,
+        timestamp,
+      });
+      eventWindow.current.add({ timestamp });
+    });
+  }, [profiles, enabled]);
+
+  // Track segment ENTER events
+  useEffect(() => {
+    if (!enabled) return;
+
+    segmentEvents.forEach((event) => {
+      if (event.action === 'ENTER') {
+        const timestamp = new Date(event.ts).getTime();
+        enterWindow.current.add({ timestamp });
+      }
+    });
+  }, [segmentEvents, enabled]);
+
+  // Update KPIs at ~1s interval
+  useEffect(() => {
+    if (!enabled) {
+      // Reset when disabled
+      profileWindow.current.clear();
+      eventWindow.current.clear();
+      enterWindow.current.clear();
+      setSparklineData([]);
+      setKpis({
+        activeProfiles: 0,
+        eventsPerMinute: 0,
+        segmentEntersPerMinute: 0,
+        segmentEntersHistory: [],
+      });
+      return;
+    }
+
+    const interval = setInterval(() => {
+      const activeProfiles = profileWindow.current.uniqueCount();
+      const eventsPerMinute = eventWindow.current.getRatePerMinute();
+      const segmentEntersPerMinute = enterWindow.current.getRatePerMinute();
+
+      // Update sparkline data (keep last 120 points = 2 minutes)
+      setSparklineData((prev) => {
+        const newData = [...prev, segmentEntersPerMinute];
+        return newData.slice(-120); // Keep last 120 points
+      });
+
+      setKpis({
+        activeProfiles,
+        eventsPerMinute,
+        segmentEntersPerMinute,
+        segmentEntersHistory: sparklineData,
+      });
+    }, 1000); // Update every 1s
+
+    return () => clearInterval(interval);
+  }, [enabled, sparklineData]);
+
+  return kpis;
+}

--- a/ui/src/lib/useCdpKpis.ts
+++ b/ui/src/lib/useCdpKpis.ts
@@ -106,19 +106,22 @@ export function useCdpKpis(enabled: boolean = true): CdpKpis {
       // Update sparkline data (keep last 120 points = 2 minutes)
       setSparklineData((prev) => {
         const newData = [...prev, segmentEntersPerMinute];
-        return newData.slice(-120); // Keep last 120 points
-      });
+        const updated = newData.slice(-120); // Keep last 120 points
 
-      setKpis({
-        activeProfiles,
-        eventsPerMinute,
-        segmentEntersPerMinute,
-        segmentEntersHistory: sparklineData,
+        // Update KPIs with the new sparkline data
+        setKpis({
+          activeProfiles,
+          eventsPerMinute,
+          segmentEntersPerMinute,
+          segmentEntersHistory: updated,
+        });
+
+        return updated;
       });
     }, 1000); // Update every 1s
 
     return () => clearInterval(interval);
-  }, [enabled, sparklineData]);
+  }, [enabled]);
 
   return kpis;
 }


### PR DESCRIPTION
## Summary
Implements [L5] UI: KPIs & sparkline (CDP) from docs/TICKETS.md

This PR adds real-time KPI metrics and a sparkline visualization for the CDP tab:

### KPIs:
- **Active Profiles (5m)**: Unique profiles seen in last 5 minutes
- **Events/min**: Rate of all CDP profile updates per minute
- **Segment ENTERs/min**: Rate of segment ENTER events per minute

### Sparkline:
- Chart.js visualization showing ENTERs/min for last 2 minutes
- 120 data points (1 per second)
- Smooth scrolling without jank using `requestAnimationFrame`

### Implementation Details:
- Created `SlidingWindow` utility class for time-based aggregations
- Created `useCdpKpis` hook that subscribes to both `/sse/cdp/profiles` and `/sse/cdp/segments`
- Throttled rendering to 1s intervals to prevent UI jank
- Added Chart.js CDN for sparkline rendering
- Comprehensive unit tests for sliding window logic (12 tests, all passing)
- Empty/loading states when simulator not running

### Test Plan:
- [x] Unit tests pass (12/12 tests for sliding window logic)
- [ ] Manual test: Start CDP simulator and verify KPIs update in real-time
- [ ] Manual test: Verify sparkline scrolls smoothly
- [ ] Manual test: Verify empty state shows when simulator not running
- [ ] UI CI green

Closes #L5

🤖 Generated with [Claude Code](https://claude.com/claude-code)